### PR TITLE
showcase: need to escape "%" in hardcoded strings when query is mixed with named args

### DIFF
--- a/test_samples.py
+++ b/test_samples.py
@@ -76,7 +76,7 @@ def test_like_clause_with_percentage_harcoded(cursor):
     )
     SELECT id, message
     FROM sampled
-    WHERE message LIKE 'th%'
+    WHERE message LIKE 'th%%'
     """
     args = {"size": 3}
     cursor.execute(qry, args)

--- a/test_samples.py
+++ b/test_samples.py
@@ -64,3 +64,21 @@ def test_multiple_args(cursor):
     id, message = rows[0]
     assert id == 3 
     assert message == "third comment"
+
+
+def test_like_clause_with_percentage_harcoded(cursor):
+    qry = """
+    WITH sampled AS (
+      SELECT *
+      FROM comments
+      ORDER BY id DESC
+      LIMIT %(size)s
+    )
+    SELECT id, message
+    FROM sampled
+    WHERE message LIKE 'th%'
+    """
+    args = {"size": 3}
+    cursor.execute(qry, args)
+    rows = cursor.fetchall()
+    assert len(rows) == 2


### PR DESCRIPTION
### description

When we have a query that has hardcoded content with `%`, as well as named arguments, it turns out psycopg2 will complain and raise a

> `psycopg2.ProgrammingError: argument formats can't be mixed`

You can see here [in the first commit](https://github.com/mt-kelvintaywl/psycopg2-exploration/commit/24f7766b37d8073f23dad2621d47161b69577a9f), that this error is reproduced in the [failed CI build](https://circleci.com/gh/mt-kelvintaywl/psycopg2-exploration/5?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

The fix, [in the 2nd commit](https://github.com/mt-kelvintaywl/psycopg2-exploration/pull/1/commits/b7a960cca3a50f9850a9f19f1cbe317ff13a617d), is to simply escape that hardcoded `%` to `%%`.
